### PR TITLE
Allow commands to control palette closing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ search, navigate, and perform actions without leaving their keyboard. It is avai
 - **SLDS Integration**: Uses Salesforce Lightning Design System for a native look and feel
 - **Modern Architecture**: Built with [LWC OSS](https://lwc.dev/) (Lightning Web Components) for composable UI
 - **Dynamic Setup Menu Commands**: Fetches and caches Salesforce setup menu items directly from your org for quick access
+- **Command-Controlled Palette Closing**: Commands can keep the palette open after execution when appropriate
 
 ## Installation
 

--- a/src/content_scripts/modules/x/commandClassRegister/AuthorizeExtensionCommand.js
+++ b/src/content_scripts/modules/x/commandClassRegister/AuthorizeExtensionCommand.js
@@ -12,11 +12,12 @@ export default class AuthorizeExtensionCommand extends Command {
   /**
    * Executes the command: invokes auth flow,  calls refresh command list.
    * @param {object} [options] Execution options (unused).
-   * @returns {Promise<void>}
+   * @returns {Promise<boolean>} whether the palette should close
    */
   async execute(options) {
     console.log('AuthorizeExtensionCommand.execute');
     await new Channel(CHANNEL_INVOKE_AUTH_FLOW).publish();
     console.log('auth flow invoked');
+    return false;
   }
 }

--- a/src/content_scripts/modules/x/commandClassRegister/Command.js
+++ b/src/content_scripts/modules/x/commandClassRegister/Command.js
@@ -14,8 +14,9 @@ export default class Command {
 
   /**
    * Execute the command's action.
+   *
    * @param {object} [options] - Optional parameters for execution (e.g., openInNewTab).
-   * @returns {Promise<any>}
+   * @returns {Promise<boolean>} whether the palette should close after executing
    */
   execute(options) {
     return Promise.reject(

--- a/src/content_scripts/modules/x/commandClassRegister/NavigationCommand.js
+++ b/src/content_scripts/modules/x/commandClassRegister/NavigationCommand.js
@@ -18,7 +18,7 @@ export default class NavigationCommand extends Command {
    * Navigate to the command's path.
    * @param {object} [options]
    * @param {boolean} [options.openInNewTab] - If true, opens in a new tab.
-   * @returns {Promise<void>}
+   * @returns {Promise<boolean>} whether the palette should close
    */
   execute({ openInNewTab = false } = {}) {
     const url = `${window.location.origin}${this.path}`;
@@ -27,6 +27,6 @@ export default class NavigationCommand extends Command {
     } else {
       window.location.href = url;
     }
-    return Promise.resolve();
+    return Promise.resolve(true);
   }
 }

--- a/src/content_scripts/modules/x/commandClassRegister/RefreshCommandListCommand.js
+++ b/src/content_scripts/modules/x/commandClassRegister/RefreshCommandListCommand.js
@@ -22,12 +22,13 @@ export default class RefreshCommandListCommand extends Command {
   /**
    * Executes the command: clears cache and dispatches refresh event.
    * @param {object} [options] Execution options (unused).
-   * @returns {Promise<void>}
+   * @returns {Promise<boolean>} whether the palette should close
    */
   async execute(options) {
     console.log('RefreshCommandListCommand.execute');
     const cache = new CacheManager(toLightningHostname(this.hostname));
     await COMMAND_CACHE_KEYS.forEach((key) => cache.clear(key));
     await new Channel(CHANNEL_GET_COMMANDS).publish();
+    return false;
   }
 }

--- a/src/content_scripts/modules/x/commandItem/commandItem.js
+++ b/src/content_scripts/modules/x/commandItem/commandItem.js
@@ -30,13 +30,15 @@ export default class CommandItem extends LightningElement {
   }
 
   /**
-   * Execute this command and close the palette.
+   * Execute this command and close the palette when desired by the command.
    * @param {boolean} openInNewTab
+   * @returns {Promise<void>}
    */
   @api async select(openInNewTab = false) {
-    await this.command.execute({ openInNewTab });
-    // todo: closing should be handled by the command, some commands may not want to close the palette
-    this.dispatchEvent(new CustomEvent('close', { bubbles: true }));
+    const shouldClose = await this.command.execute({ openInNewTab });
+    if (shouldClose !== false) {
+      this.dispatchEvent(new CustomEvent('close', { bubbles: true }));
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- enable commands to specify if the palette should close
- honor command response when closing palette
- document new behaviour in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685472489f248328a7a24305ceda3020