### PR TITLE
Add LWC options page and improve popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ version might occasionally lag behind the latest release.
 2. Press `Ctrl+Shift+L` (or `Cmd+Shift+P` on Mac) to open the command palette
 3. Type commands or search terms to find what you need
 4. Press Enter to execute the selected command
+5. Open the extension popup from the toolbar icon for quick help and a link to Settings
 
 ### Supported Domains
 
@@ -93,7 +94,8 @@ action.
   the background script
 - **LWC Components** (`src/content_scripts/modules/x`): Lightning Web Components that provide the UI for the command
   palette
-- **Popup** (`src/popup.html/js`): Extension popup interface (currently a basic scaffold)
+- **Popup** (`src/popup.html/js`): Provides quick usage tips and links to settings and GitHub
+- **Options Page** (`src/options.html/js` and `src/options/modules`): Settings UI built with LWC
 - **Shared Utilities** (`src/shared`): Common modules for background and content scripts, including the Channel messaging wrapper
 
 ### Build & Toolchain

--- a/lwc.config.json
+++ b/lwc.config.json
@@ -2,6 +2,9 @@
   "modules": [
     {
       "dir": "src/content_scripts/modules"
+    },
+    {
+      "dir": "src/options/modules"
     }
   ]
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,6 +10,10 @@
     "default_icon": "icons/icon48.png",
     "default_popup": "popup.html"
   },
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
+  },
   "icons": {
     "16": "icons/icon16.png",
     "32": "icons/icon32.png",

--- a/src/options.html
+++ b/src/options.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Force Navigator Settings</title>
+  </head>
+  <body>
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/src/options.js
+++ b/src/options.js
@@ -1,0 +1,11 @@
+import { createElement } from 'lwc';
+import OptionsApp from 'x/optionsApp';
+
+/**
+ * Mount the options page LWC component once DOM is ready.
+ * @returns {void}
+ */
+document.addEventListener('DOMContentLoaded', () => {
+  const elm = createElement('x-options-app', { is: OptionsApp });
+  document.body.appendChild(elm);
+});

--- a/src/options/modules/x/optionsApp/optionsApp.html
+++ b/src/options/modules/x/optionsApp/optionsApp.html
@@ -1,0 +1,4 @@
+<template>
+  <h1>Force Navigator Reloaded Settings</h1>
+  <p>Configuration options will be available here in future versions.</p>
+</template>

--- a/src/options/modules/x/optionsApp/optionsApp.js
+++ b/src/options/modules/x/optionsApp/optionsApp.js
@@ -1,0 +1,6 @@
+import { LightningElement } from 'lwc';
+
+/**
+ * Root component for the options page.
+ */
+export default class OptionsApp extends LightningElement {}

--- a/src/popup.html
+++ b/src/popup.html
@@ -5,7 +5,35 @@
     <title>Popup</title>
   </head>
   <body>
-    <div id="app"></div>
+    <h1>Force Navigator Reloaded</h1>
+    <p>
+      Open the command palette with <strong>Ctrl+Shift+L</strong> (Windows) or
+      <strong>Cmd+Shift+P</strong> (Mac). You can customize this shortcut in
+      <a href="chrome://extensions/shortcuts" target="_blank"
+        >Chrome shortcut settings</a
+      >.
+    </p>
+    <p>
+      <a id="settings-link" href="#">Settings</a>
+      |
+      <a
+        id="github-link"
+        href="https://github.com/Damecek/force-navigator-reloaded"
+        target="_blank"
+        >GitHub</a
+      >
+      |
+      <a
+        id="issues-link"
+        href="https://github.com/Damecek/force-navigator-reloaded/issues"
+        target="_blank"
+        >Report issues</a
+      >
+    </p>
+    <p>
+      Contributions are welcome! Visit the GitHub repository to file issues or
+      submit pull requests.
+    </p>
     <script src="popup.js"></script>
   </body>
 </html>

--- a/src/popup.js
+++ b/src/popup.js
@@ -3,6 +3,13 @@
  * @returns {void}
  */
 document.addEventListener('DOMContentLoaded', () => {
-  const app = document.getElementById('app');
-  app.textContent = 'Hello from popup!';
+  const settings = document.getElementById('settings-link');
+  if (settings) {
+    settings.addEventListener('click', (event) => {
+      event.preventDefault();
+      if (chrome.runtime.openOptionsPage) {
+        chrome.runtime.openOptionsPage();
+      }
+    });
+  }
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,7 @@ module.exports = (env, argv) => {
       background: path.resolve(__dirname, 'src/background/index.js'),
       content: path.resolve(__dirname, 'src/content_scripts/content.js'),
       popup: path.resolve(__dirname, 'src/popup.js'),
+      options: path.resolve(__dirname, 'src/options.js'),
     },
     output: {
       filename: '[name].js',
@@ -80,6 +81,7 @@ module.exports = (env, argv) => {
             },
           },
           { from: 'src/popup.html', to: 'popup.html' },
+          { from: 'src/options.html', to: 'options.html' },
           { from: 'src/icons', to: 'icons' },
         ],
       }),


### PR DESCRIPTION
## Summary
- convert options page to use LWC
- expose options modules to lwc-oss
- remove unused popup JS and add contribution links

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685e6546a584832892f1c3e3e2185eba