### PR TITLE
Add static commands for Developer Console and Agentforce Vibes

### DIFF
--- a/src/background/staticCommands.js
+++ b/src/background/staticCommands.js
@@ -40,4 +40,14 @@ export const staticCommands = [
     label: 'Application > Files > Home',
     path: '/lightning/o/ContentDocument/home',
   },
+  {
+    id: 'developer-console',
+    label: 'Developer Console',
+    path: '/_ui/common/apex/debug/ApexCSIPage',
+  },
+  {
+    id: 'agentforce-vibes',
+    label: 'Agentforce Vibes',
+    path: '/runtime_developerplatform_codebuilder/codebuilder.app?launch=true',
+  },
 ];


### PR DESCRIPTION
### Motivation
- Provide quick, always-available shortcuts to common developer tools from the command palette so users can open the Developer Console and Agentforce Code Builder without needing dynamic metadata fetching.

### Description
- Add two entries to `staticCommands` in `src/background/staticCommands.js`: `developer-console` with path `/_ui/common/apex/debug/ApexCSIPage` and `agentforce-vibes` with path `/runtime_developerplatform_codebuilder/codebuilder.app?launch=true`.
- Document the new static shortcuts in `README.md` by adding a `Static Shortcuts` feature line.

### Testing
- Pre-commit hooks ran `prettier --write` (via `lint-staged`) and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a224ea5d0832884cf9a11a91caf76)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Developer Console command for apex code debugging.
  * Added Agentforce Vibes command for code builder application access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->