### PR TITLE
Add Help (?) button to command palette that opens extension popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ version might occasionally lag behind the latest release.
 3. Type commands or search terms to find what you need
 4. Press Enter to execute the selected command
 5. Press `Esc` or the same shortcut again to close the command palette when it has focus
-6. Open the extension popup from the toolbar icon for quick help and a link to Settings
+6. Use the `?` help button in the palette header (or the toolbar icon) to open the extension popup with shortcuts and Settings
 7. Use the Settings page to edit the JSON configuration, tailoring which command sources (Setup nodes, objects, flows, custom commands) appear in the palette
 
 ### Supported Domains

--- a/backlog.md
+++ b/backlog.md
@@ -74,5 +74,5 @@ another example of such is `New Report`
 - [ ] automatically refresh specific metadata on specific pages, e.g. when creating new object/field, when creating new
       flow version etc.
 - [x] in option show list command usage
-- [ ] next to X icon for closing, add new hover button ? with short help text about extension, closing, opening
+- [x] next to X icon for closing, add new hover button ? with short help text about extension, closing, opening
       shortcuts and where to configure them

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -4,6 +4,7 @@ import {
   CHANNEL_COMPLETED_AUTH_FLOW,
   CHANNEL_INVOKE_AUTH_FLOW,
   CHANNEL_OPEN_OPTIONS,
+  CHANNEL_OPEN_POPUP,
   CHANNEL_REFRESH_COMMANDS,
   CHANNEL_SEND_COMMANDS,
   CHANNEL_TOGGLE_COMMAND_PALETTE,
@@ -56,6 +57,14 @@ new Channel(CHANNEL_OPEN_OPTIONS).subscribe(() => {
     return chrome.runtime.openOptionsPage();
   } else {
     return console.warn('openOptionsPage is not supported');
+  }
+});
+
+new Channel(CHANNEL_OPEN_POPUP).subscribe(() => {
+  if (chrome.action?.openPopup) {
+    return chrome.action.openPopup();
+  } else {
+    return console.warn('openPopup is not supported');
   }
 });
 

--- a/src/content_scripts/modules/x/commandPallet/commandPallet.css
+++ b/src/content_scripts/modules/x/commandPallet/commandPallet.css
@@ -24,3 +24,13 @@ x-command-pallet .modal-container.slds-modal__container {
     max-width: 50rem;
     padding-bottom: 20rem;
 }
+
+x-command-pallet .command-pallet__help-icon {
+    align-items: center;
+    display: inline-flex;
+    font-size: 1.1rem;
+    font-weight: 600;
+    height: 1.5rem;
+    justify-content: center;
+    width: 1.5rem;
+}

--- a/src/content_scripts/modules/x/commandPallet/commandPallet.html
+++ b/src/content_scripts/modules/x/commandPallet/commandPallet.html
@@ -7,25 +7,35 @@
     tabindex="-1"
   >
     <div class="modal-container slds-modal__container">
-      <button
-        class="slds-button slds-button_icon slds-modal__close"
-        onclick={handleClose}
-      >
-        <svg
-          aria-hidden="true"
-          class="slds-button__icon slds-button__icon_large"
-          focusable="false"
-          part="icon"
-          viewBox="0 0 520 520"
+      <div class="slds-grid slds-align-bottom">
+        <button
+          class="slds-button slds-button_icon slds-modal__close"
+          onclick={handleHelp}
+          title="Help"
         >
-          <g>
-            <path
-              d="M310 254l130-131c6-6 6-15 0-21l-20-21c-6-6-15-6-21 0L268 212a10 10 0 01-14 0L123 80c-6-6-15-6-21 0l-21 21c-6 6-6 15 0 21l131 131c4 4 4 10 0 14L80 399c-6 6-6 15 0 21l21 21c6 6 15 6 21 0l131-131a10 10 0 0114 0l131 131c6 6 15 6 21 0l21-21c6-6 6-15 0-21L310 268a10 10 0 010-14z"
-            ></path>
-          </g>
-        </svg>
-        <span class="slds-assistive-text">Cancel and close</span>
-      </button>
+          <span aria-hidden="true" class="command-pallet__help-icon">?</span>
+          <span class="slds-assistive-text">Help</span>
+        </button>
+        <button
+          class="slds-button slds-button_icon slds-modal__close"
+          onclick={handleClose}
+        >
+          <svg
+            aria-hidden="true"
+            class="slds-button__icon slds-button__icon_large"
+            focusable="false"
+            part="icon"
+            viewBox="0 0 520 520"
+          >
+            <g>
+              <path
+                d="M310 254l130-131c6-6 6-15 0-21l-20-21c-6-6-15-6-21 0L268 212a10 10 0 01-14 0L123 80c-6-6-15-6-21 0l-21 21c-6 6-6 15 0 21l131 131c4 4 4 10 0 14L80 399c-6 6-6 15 0 21l21 21c6 6 15 6 21 0l131-131a10 10 0 0114 0l131 131c6 6 15 6 21 0l21-21c6-6 6-15 0-21L310 268a10 10 0 010-14z"
+              ></path>
+            </g>
+          </svg>
+          <span class="slds-assistive-text">Cancel and close</span>
+        </button>
+      </div>
       <div class="slds-modal__header">
         <h1 class="slds-modal__title slds-hyphenate" tabindex="-1">
           Command Palette

--- a/src/content_scripts/modules/x/commandPallet/commandPallet.js
+++ b/src/content_scripts/modules/x/commandPallet/commandPallet.js
@@ -1,6 +1,7 @@
 import { api, LightningElement, track } from 'lwc';
 import uFuzzy from '@leeoniya/ufuzzy';
 import VirtualScroller from '../../virtualScroller/virtualScroller';
+import { Channel, CHANNEL_OPEN_POPUP } from '../../../../shared';
 
 export default class CommandPallet extends LightningElement {
   static renderMode = 'light';
@@ -148,6 +149,13 @@ export default class CommandPallet extends LightningElement {
 
   handleClose() {
     this.dispatchEvent(new CustomEvent('close', { bubbles: true }));
+  }
+
+  /**
+   * Open the extension popup with shortcuts and settings.
+   */
+  handleHelp() {
+    new Channel(CHANNEL_OPEN_POPUP).publish();
   }
 
   /**

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -77,4 +77,5 @@ export const CHANNEL_SEND_COMMANDS = 'sendCommands';
 export const CHANNEL_INVOKE_AUTH_FLOW = 'invokeAuthFlow';
 export const CHANNEL_COMPLETED_AUTH_FLOW = 'completedAuthFlow';
 export const CHANNEL_OPEN_OPTIONS = 'openOptions';
+export const CHANNEL_OPEN_POPUP = 'openPopup';
 export const CHANNEL_TOGGLE_COMMAND_PALETTE = 'toggleCommandPalette';


### PR DESCRIPTION
### Motivation
- Provide quick access to the extension popup (shortcuts and settings) directly from the command palette header. 
- Surface a small contextual help affordance so users can discover how to configure and close the palette. 
- Mark the backlog task as completed for this UX improvement.

### Description
- Added a `?` help button to the command palette header that calls a new `handleHelp` method in `CommandPallet` and publishes `CHANNEL_OPEN_POPUP` via `Channel` (`src/content_scripts/modules/x/commandPallet/commandPallet.html`, `commandPallet.js`).
- Introduced `CHANNEL_OPEN_POPUP` to shared constants and wired a background subscriber that calls `chrome.action.openPopup()` when supported (`src/shared/constants.js`, `src/background/index.js`).
- Added minimal styling for the new help button (`src/content_scripts/modules/x/commandPallet/commandPallet.css`).
- Documentation updates: mention the `?` help button in `README.md` and mark the backlog item complete in `backlog.md`.

### Testing
- Pre-commit formatting (`prettier` via `lint-staged`) ran as part of the commit hook and completed successfully. 
- No unit or integration tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a21e831308328b21a69fa3ad071c7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a help button (?) to the palette header that opens the extension popup with shortcuts and Settings.

* **Documentation**
  * Updated Usage guide to reflect the new help button location and how to access it via the palette header or toolbar icon.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->