### PR TITLE
Localize command labels and dynamic prefixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,3 +48,6 @@
 - Use JSDoc comments to document public APIs and to introduce types for parameters and return values.
 - Do not litter code with comments //.
 - Use `console.log` for debugging; logs are stripped in production builds, so avoid excessive or obsolete statements.
+- When adding user-facing text, add a matching entry to `src/_locales/en/messages.json` and use `getMessage`,
+  `getLabels`, or `applyI18n` to surface localized strings. Use `getMessage` with substitutions for dynamic command
+  labels that include runtime values.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ search, navigate, and perform actions without leaving their keyboard. It is avai
 - **Usage-based Sorting**: Frequently executed commands appear higher in search results
 - **Usage Insights**: Review command execution counts directly on the Settings page to understand which commands power
   workflows the most
+- **Localization-ready UI**: Uses the Chrome i18n system for extension strings across the popup, options, and command
+  palette
 
 ### Fuzzy Search
 

--- a/backlog.md
+++ b/backlog.md
@@ -49,7 +49,7 @@ another example of such is `New Report`
 
 - [x] performance: instantiate commands only on click/select in the command item class, now it is instantiated on
       command list load
-- [ ] [internationalize](https://developer.chrome.com/docs/extensions/reference/api/i18n#concepts_and_usage) the
+- [x] [internationalize](https://developer.chrome.com/docs/extensions/reference/api/i18n#concepts_and_usage) the
       extension
 - [ ] visualize the user running process, e.g. on command refresh, either spinner or toast or some other indication that
       task started and finished

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1,0 +1,221 @@
+{
+  "extensionName": {
+    "message": "Force Navigator Reloaded"
+  },
+  "extensionDescription": {
+    "message": "Fast, efficient Salesforce Lightning navigation with a command palette—search and act without leaving your keyboard."
+  },
+  "commandTogglePaletteDescription": {
+    "message": "Toggle Command Palette"
+  },
+  "popupMetaDescription": {
+    "message": "Quick reference for Force Navigator Reloaded extension shortcuts and settings."
+  },
+  "popupShortcutHeading": {
+    "message": "Shortcut"
+  },
+  "popupShortcutIntro": {
+    "message": "Open the command palette with"
+  },
+  "popupShortcutWindowsSuffix": {
+    "message": "(Windows) or"
+  },
+  "popupShortcutMacSuffix": {
+    "message": "(Mac)."
+  },
+  "popupShortcutChangeIntro": {
+    "message": "You can change this in"
+  },
+  "popupShortcutLink": {
+    "message": "Chrome Extension Shortcuts"
+  },
+  "popupShortcutClosePrefix": {
+    "message": "Press the shortcut again or"
+  },
+  "popupShortcutCloseSuffix": {
+    "message": "to close the palette."
+  },
+  "popupAdvancedIntro": {
+    "message": "For advanced configuration open"
+  },
+  "popupSettingsLink": {
+    "message": "Settings"
+  },
+  "popupContribute": {
+    "message": "We ❤️ contributions! Feel free to open an issue or send a PR on GitHub."
+  },
+  "popupReviewIntro": {
+    "message": "If you enjoy using Force Navigator Reloaded,"
+  },
+  "popupReviewLink": {
+    "message": "please leave a review"
+  },
+  "popupFooterRepository": {
+    "message": "Repository"
+  },
+  "popupFooterReportIssue": {
+    "message": "Report issue"
+  },
+  "popupFooterAuthor": {
+    "message": "Author"
+  },
+  "optionsPageTitle": {
+    "message": "Force Navigator Settings"
+  },
+  "optionsTitle": {
+    "message": "Force Navigator Reloaded Settings"
+  },
+  "optionsSettingsHeading": {
+    "message": "Settings"
+  },
+  "optionsCommandUsageHeading": {
+    "message": "Command Usage"
+  },
+  "optionsResetDefaults": {
+    "message": "Reset to Defaults"
+  },
+  "optionsSave": {
+    "message": "Save"
+  },
+  "errorLoadSettings": {
+    "message": "Unable to load settings"
+  },
+  "errorSaveSettings": {
+    "message": "Unable to save settings"
+  },
+  "errorResetSettings": {
+    "message": "Unable to reset settings"
+  },
+  "errorInvalidJson": {
+    "message": "Invalid JSON"
+  },
+  "errorLoadUsage": {
+    "message": "Unable to load usage statistics"
+  },
+  "commandPaletteHelpTitle": {
+    "message": "Help"
+  },
+  "commandPaletteHelpAssistive": {
+    "message": "Help"
+  },
+  "commandPaletteCloseAssistive": {
+    "message": "Cancel and close"
+  },
+  "commandPaletteTitle": {
+    "message": "Command Palette"
+  },
+  "commandPaletteCommandLabel": {
+    "message": "Command"
+  },
+  "commandPalettePlaceholder": {
+    "message": "Type a command..."
+  },
+  "commandPaletteShowCommandsTitle": {
+    "message": "Show commands"
+  },
+  "commandPaletteCommandsAriaLabel": {
+    "message": "Commands"
+  },
+  "commandLabelRefreshCommandList": {
+    "message": "Extension > Refresh Command List"
+  },
+  "commandLabelResetUsageTracking": {
+    "message": "Extension > Reset Command List Usage Tracking"
+  },
+  "commandLabelAuthorize": {
+    "message": "Extension > Authorize"
+  },
+  "commandLabelOptions": {
+    "message": "Extension > Options"
+  },
+  "commandStaticNewCustomObject": {
+    "message": "Object Manager > New Custom Object"
+  },
+  "commandStaticNewFlow": {
+    "message": "Platform Tools > Process Automation > New Flow Automation"
+  },
+  "commandStaticFlowTriggerExplorer": {
+    "message": "Platform Tools > Process Automation > Flow Trigger Explorer"
+  },
+  "commandStaticAppHome": {
+    "message": "Application > Home"
+  },
+  "commandStaticFilesHome": {
+    "message": "Application > Files > Home"
+  },
+  "commandStaticDeveloperConsole": {
+    "message": "Developer Console"
+  },
+  "commandStaticAgentforceVibes": {
+    "message": "Agentforce Vibes"
+  },
+  "objectManagerFieldsRelationships": {
+    "message": "Fields & Relationships"
+  },
+  "objectManagerPageLayouts": {
+    "message": "Page Layouts"
+  },
+  "objectManagerLightningPages": {
+    "message": "Lightning Pages"
+  },
+  "objectManagerButtonsLinksActions": {
+    "message": "Buttons, Links, and Actions"
+  },
+  "objectManagerCompactLayouts": {
+    "message": "Compact Layouts"
+  },
+  "objectManagerFieldSets": {
+    "message": "Field Sets"
+  },
+  "objectManagerObjectLimits": {
+    "message": "Object Limits"
+  },
+  "objectManagerRecordTypes": {
+    "message": "Record Types"
+  },
+  "objectManagerRelatedLookupFilters": {
+    "message": "Related Lookup Filters"
+  },
+  "objectManagerSearchLayouts": {
+    "message": "Search Layouts"
+  },
+  "objectManagerObjectAccess": {
+    "message": "Object Access"
+  },
+  "objectManagerApexTriggers": {
+    "message": "Apex Triggers"
+  },
+  "objectManagerFlowTriggers": {
+    "message": "Flow Triggers"
+  },
+  "objectManagerValidationRules": {
+    "message": "Validation Rules"
+  },
+  "commandLabelCustomMetadataNew": {
+    "message": "Custom Metadata Types > $1 > New"
+  },
+  "commandLabelCustomMetadataList": {
+    "message": "Custom Metadata Types > $1 > List"
+  },
+  "commandLabelObjectManagerDetails": {
+    "message": "Object Manager > $1 > Details"
+  },
+  "commandLabelObjectManagerSection": {
+    "message": "Object Manager > $1 > $2"
+  },
+  "commandLabelApplicationNew": {
+    "message": "Application > $1 > New"
+  },
+  "commandLabelApplicationListView": {
+    "message": "Application > $1 > List View"
+  },
+  "commandLabelFlowDefinition": {
+    "message": "Flow > Definition > $1"
+  },
+  "commandLabelFlowLatest": {
+    "message": "Flow > Latest Version > $1"
+  },
+  "commandLabelFlowActive": {
+    "message": "Flow > Active Version > $1"
+  }
+}

--- a/src/background/commandRegister.js
+++ b/src/background/commandRegister.js
@@ -12,6 +12,8 @@ import {
   FLOW_DEFINITION_SETTINGS_KEY,
   FLOW_DEFINITION_TYPE,
   FLOW_LATEST_VERSION_TYPE,
+  getMessage,
+  getLabels,
   getSetting,
   MENU_CACHE_KEY,
   MENU_CACHE_TTL,
@@ -41,89 +43,106 @@ import {
 } from './salesforceUtils';
 import { SalesforceConnection } from './salesforceConnection';
 
+const labels = getLabels([
+  'objectManagerFieldsRelationships',
+  'objectManagerPageLayouts',
+  'objectManagerLightningPages',
+  'objectManagerButtonsLinksActions',
+  'objectManagerCompactLayouts',
+  'objectManagerFieldSets',
+  'objectManagerObjectLimits',
+  'objectManagerRecordTypes',
+  'objectManagerRelatedLookupFilters',
+  'objectManagerSearchLayouts',
+  'objectManagerObjectAccess',
+  'objectManagerApexTriggers',
+  'objectManagerFlowTriggers',
+  'objectManagerValidationRules',
+]);
+
 const OBJECT_MANAGER_SECTIONS = [
   {
     settingKey: SOBJECT_FIELDS_RELATIONSHIPS_ENTITY_TYPE,
     id: 'fields-and-relationship',
-    label: 'Fields & Relationships',
+    label: labels.objectManagerFieldsRelationships,
     pathSuffix: 'FieldsAndRelationships/view',
   },
   {
     settingKey: SOBJECT_PAGE_LAYOUTS_ENTITY_TYPE,
     id: 'page-layouts',
-    label: 'Page Layouts',
+    label: labels.objectManagerPageLayouts,
     pathSuffix: 'PageLayouts/view',
   },
   {
     settingKey: SOBJECT_LIGHTNING_PAGES_ENTITY_TYPE,
     id: 'lightning-pages',
-    label: 'Lightning Pages',
+    label: labels.objectManagerLightningPages,
     pathSuffix: 'LightningPages/view',
   },
   {
     settingKey: SOBJECT_BUTTONS_LINKS_ACTIONS_ENTITY_TYPE,
     id: 'buttons-links-actions',
-    label: 'Buttons, Links, and Actions',
+    label: labels.objectManagerButtonsLinksActions,
     pathSuffix: 'ButtonsLinksActions/view',
   },
   {
     settingKey: SOBJECT_COMPACT_LAYOUTS_ENTITY_TYPE,
     id: 'compact-layouts',
-    label: 'Compact Layouts',
+    label: labels.objectManagerCompactLayouts,
     pathSuffix: 'CompactLayouts/view',
   },
   {
     settingKey: SOBJECT_FIELD_SETS_ENTITY_TYPE,
     id: 'field-sets',
-    label: 'Field Sets',
+    label: labels.objectManagerFieldSets,
     pathSuffix: 'FieldSets/view',
   },
   {
     settingKey: SOBJECT_LIMITS_ENTITY_TYPE,
     id: 'limits',
-    label: 'Object Limits',
+    label: labels.objectManagerObjectLimits,
     pathSuffix: 'Limits/view',
   },
   {
     settingKey: SOBJECT_RECORD_TYPES_ENTITY_TYPE,
     id: 'record-types',
-    label: 'Record Types',
+    label: labels.objectManagerRecordTypes,
     pathSuffix: 'RecordTypes/view',
   },
   {
     settingKey: SOBJECT_RELATED_LOOKUP_FILTERS_ENTITY_TYPE,
     id: 'related-lookup-filters',
-    label: 'Related Lookup Filters',
+    label: labels.objectManagerRelatedLookupFilters,
     pathSuffix: 'RelatedLookupFilters/view',
   },
   {
     settingKey: SOBJECT_SEARCH_LAYOUTS_ENTITY_TYPE,
     id: 'search-layouts',
-    label: 'Search Layouts',
+    label: labels.objectManagerSearchLayouts,
     pathSuffix: 'SearchLayouts/view',
   },
   {
     settingKey: SOBJECT_OBJECT_ACCESS_ENTITY_TYPE,
     id: 'object-access',
-    label: 'Object Access',
+    label: labels.objectManagerObjectAccess,
     pathSuffix: 'ObjectAccess/view',
   },
   {
     settingKey: SOBJECT_APEX_TRIGGERS_ENTITY_TYPE,
     id: 'apex-triggers',
-    label: 'Apex Triggers',
+    label: labels.objectManagerApexTriggers,
     pathSuffix: 'ApexTriggers/view',
   },
   {
     settingKey: SOBJECT_FLOW_TRIGGERS_ENTITY_TYPE,
     id: 'flow-triggers',
-    label: 'Flow Triggers',
+    label: labels.objectManagerFlowTriggers,
     pathSuffix: 'FlowTriggers/view',
   },
   {
     settingKey: SOBJECT_VALIDATION_RULES_ENTITY_TYPE,
     id: 'validation-rules',
-    label: 'Validation Rules',
+    label: labels.objectManagerValidationRules,
     pathSuffix: 'ValidationRules/view',
   },
 ];
@@ -280,26 +299,29 @@ async function getEntityCommands(hostname, connection) {
       if (QualifiedApiName.endsWith('__mdt') && includeCustomMetadata) {
         commands.push({
           id: `custommetadata-new-${KeyPrefix}`,
-          label: `Custom Metadata Types > ${Label} > New`,
+          label: getMessage('commandLabelCustomMetadataNew', Label),
           path: `/lightning/setup/CustomMetadata/page?address=/${KeyPrefix}/e`,
         });
         commands.push({
           id: `custommetadata-list-${KeyPrefix}`,
-          label: `Custom Metadata Types > ${Label} > List`,
+          label: getMessage('commandLabelCustomMetadataList', Label),
           path: `/lightning/setup/CustomMetadata/page?address=/${KeyPrefix}`,
         });
       } else {
         if (IsCustomizable && hasSObjectSettings) {
           commands.push({
             id: `sobject-setup-detail-${DurableId}`,
-            label: `Object Manager > ${Label} > Details`,
+            label: getMessage('commandLabelObjectManagerDetails', Label),
             path: `/lightning/setup/ObjectManager/${DurableId}/Details/view`,
           });
           for (const section of OBJECT_MANAGER_SECTIONS) {
             if (includeSObjectSettings[section.settingKey]) {
               commands.push({
                 id: `sobject-setup-${section.id}-${DurableId}`,
-                label: `Object Manager > ${Label} > ${section.label}`,
+                label: getMessage('commandLabelObjectManagerSection', [
+                  Label,
+                  section.label,
+                ]),
                 path: `/lightning/setup/ObjectManager/${DurableId}/${section.pathSuffix}`,
               });
             }
@@ -309,14 +331,14 @@ async function getEntityCommands(hostname, connection) {
         if (IsEverCreatable && IsCompactLayoutable) {
           commands.push({
             id: `sobject-new-${QualifiedApiName}`,
-            label: `Application > ${Label} > New`,
+            label: getMessage('commandLabelApplicationNew', Label),
             path: `/lightning/o/${QualifiedApiName}/new`,
           });
         }
         if (IsEverCreatable && IsSearchLayoutable) {
           commands.push({
             id: `sobject-list-${QualifiedApiName}`,
-            label: `Application > ${Label} > List View`,
+            label: getMessage('commandLabelApplicationListView', Label),
             path: `/lightning/o/${QualifiedApiName}/home`,
           });
         }
@@ -377,21 +399,21 @@ async function getFlowCommands(hostname, connection) {
         if (includeDefinition) {
           commands.push({
             id: `flow-definition-${f.Id}`,
-            label: `Flow > Definition > ${label}`,
+            label: getMessage('commandLabelFlowDefinition', label),
             path: `/lightning/setup/Flows/page?address=%2F${f.Id}`,
           });
         }
         if (f.LatestVersionId && includeLatest) {
           commands.push({
             id: `flow-latest-${f.Id}`,
-            label: `Flow > Latest Version > ${label}`,
+            label: getMessage('commandLabelFlowLatest', label),
             path: `/builder_platform_interaction/flowBuilder.app?flowId=${f.LatestVersionId}`,
           });
         }
         if (f.ActiveVersionId && includeActive) {
           commands.push({
             id: `flow-active-${f.Id}`,
-            label: `Flow > Active Version > ${label}`,
+            label: getMessage('commandLabelFlowActive', label),
             path: `/builder_platform_interaction/flowBuilder.app?flowId=${f.ActiveVersionId}`,
           });
         }

--- a/src/background/staticCommands.js
+++ b/src/background/staticCommands.js
@@ -3,6 +3,18 @@
  * These commands are common for all domains.
  */
 
+import { getLabels } from '../shared';
+
+const labels = getLabels([
+  'commandStaticNewCustomObject',
+  'commandStaticNewFlow',
+  'commandStaticFlowTriggerExplorer',
+  'commandStaticAppHome',
+  'commandStaticFilesHome',
+  'commandStaticDeveloperConsole',
+  'commandStaticAgentforceVibes',
+]);
+
 /**
  * @typedef {Object} Command
  * @property {string} id - Unique identifier of the command
@@ -17,37 +29,37 @@
 export const staticCommands = [
   {
     id: 'new-custom-object',
-    label: 'Object Manager > New Custom Object',
+    label: labels.commandStaticNewCustomObject,
     path: '/lightning/setup/ObjectManager/new',
   },
   {
     id: 'new-flow',
-    label: 'Platform Tools > Process Automation > New Flow Automation',
+    label: labels.commandStaticNewFlow,
     path: '/builder_platform_interaction/flowBuilder.app',
   },
   {
     id: 'flow-trigger-explorer',
-    label: 'Platform Tools > Process Automation > Flow Trigger Explorer',
+    label: labels.commandStaticFlowTriggerExplorer,
     path: '/interaction_explorer/flowExplorer.app',
   },
   {
     id: 'app-home',
-    label: 'Application > Home',
+    label: labels.commandStaticAppHome,
     path: '/lightning/page/home',
   },
   {
     id: 'files-home',
-    label: 'Application > Files > Home',
+    label: labels.commandStaticFilesHome,
     path: '/lightning/o/ContentDocument/home',
   },
   {
     id: 'developer-console',
-    label: 'Developer Console',
+    label: labels.commandStaticDeveloperConsole,
     path: '/_ui/common/apex/debug/ApexCSIPage',
   },
   {
     id: 'agentforce-vibes',
-    label: 'Agentforce Vibes',
+    label: labels.commandStaticAgentforceVibes,
     path: '/runtime_developerplatform_codebuilder/codebuilder.app?launch=true',
   },
 ];

--- a/src/content_scripts/modules/x/commandClassRegister/AuthorizeExtensionCommand.js
+++ b/src/content_scripts/modules/x/commandClassRegister/AuthorizeExtensionCommand.js
@@ -1,12 +1,22 @@
 import Command from './Command';
-import { Channel, CHANNEL_INVOKE_AUTH_FLOW } from '../../../../shared';
+import {
+  Channel,
+  CHANNEL_INVOKE_AUTH_FLOW,
+  getLabels,
+} from '../../../../shared';
+
+const labels = getLabels(['commandLabelAuthorize']);
 
 export default class AuthorizeExtensionCommand extends Command {
   /**
    * Initializes the authorization command with default id and label.
    */
   constructor({ usage } = {}) {
-    super('AuthorizeExtensionCommand', 'Extension > Authorize', usage ?? 2);
+    super(
+      'AuthorizeExtensionCommand',
+      labels.commandLabelAuthorize,
+      usage ?? 2
+    );
   }
 
   /**

--- a/src/content_scripts/modules/x/commandClassRegister/ExtensionOptionsCommand.js
+++ b/src/content_scripts/modules/x/commandClassRegister/ExtensionOptionsCommand.js
@@ -1,12 +1,14 @@
 import Command from './Command';
-import { Channel, CHANNEL_OPEN_OPTIONS } from '../../../../shared';
+import { Channel, CHANNEL_OPEN_OPTIONS, getLabels } from '../../../../shared';
+
+const labels = getLabels(['commandLabelOptions']);
 
 /**
  * Command that navigates the page to a specified path.
  */
 export default class ExtensionOptionsCommand extends Command {
   constructor({ usage } = {}) {
-    super('extension-options', 'Extension > Options', usage ?? 1);
+    super('extension-options', labels.commandLabelOptions, usage ?? 1);
   }
 
   /**

--- a/src/content_scripts/modules/x/commandClassRegister/RefreshCommandListCommand.js
+++ b/src/content_scripts/modules/x/commandClassRegister/RefreshCommandListCommand.js
@@ -4,8 +4,11 @@ import {
   Channel,
   CHANNEL_REFRESH_COMMANDS,
   COMMAND_CACHE_KEYS,
+  getLabels,
   toLightningHostname,
 } from '../../../../shared';
+
+const labels = getLabels(['commandLabelRefreshCommandList']);
 
 /**
  * Command to refresh the list of dynamic commands in the command palette.
@@ -18,7 +21,7 @@ export default class RefreshCommandListCommand extends Command {
   constructor({ usage } = {}) {
     super(
       'RefreshCommandListCommand',
-      'Extension > Refresh Command List',
+      labels.commandLabelRefreshCommandList,
       usage ?? 1
     );
   }

--- a/src/content_scripts/modules/x/commandClassRegister/ResetCommandListUsageTracking.js
+++ b/src/content_scripts/modules/x/commandClassRegister/ResetCommandListUsageTracking.js
@@ -2,8 +2,11 @@ import Command from './Command';
 import {
   Channel,
   CHANNEL_REFRESH_COMMANDS,
+  getLabels,
   UsageTracker,
 } from '../../../../shared';
+
+const labels = getLabels(['commandLabelResetUsageTracking']);
 
 /**
  * Command to reset command list usage tracking.
@@ -15,7 +18,7 @@ export default class ResetCommandListUsageTracking extends Command {
   constructor({ usage } = {}) {
     super(
       'ResetCommandListUsageTracking',
-      'Extension > Reset Command List Usage Tracking',
+      labels.commandLabelResetUsageTracking,
       usage ?? 1
     );
   }

--- a/src/content_scripts/modules/x/commandPallet/commandPallet.html
+++ b/src/content_scripts/modules/x/commandPallet/commandPallet.html
@@ -11,10 +11,12 @@
         <button
           class="slds-button slds-button_icon slds-modal__close"
           onclick={handleHelp}
-          title="Help"
+          title={labels.commandPaletteHelpTitle}
         >
           <span aria-hidden="true" class="command-pallet__help-icon">?</span>
-          <span class="slds-assistive-text">Help</span>
+          <span class="slds-assistive-text">
+            {labels.commandPaletteHelpAssistive}
+          </span>
         </button>
         <button
           class="slds-button slds-button_icon slds-modal__close"
@@ -33,17 +35,21 @@
               ></path>
             </g>
           </svg>
-          <span class="slds-assistive-text">Cancel and close</span>
+          <span class="slds-assistive-text">
+            {labels.commandPaletteCloseAssistive}
+          </span>
         </button>
       </div>
       <div class="slds-modal__header">
         <h1 class="slds-modal__title slds-hyphenate" tabindex="-1">
-          Command Palette
+          {labels.commandPaletteTitle}
         </h1>
       </div>
       <div class="slds-modal__content slds-p-around_medium">
         <div class="slds-form-element">
-          <label class="slds-form-element__label">Command</label>
+          <label class="slds-form-element__label">
+            {labels.commandPaletteCommandLabel}
+          </label>
           <div class="slds-form-element__control">
             <div class="slds-combobox_container">
               <div
@@ -69,12 +75,12 @@
                     name="command-input"
                     oninput={handleInput}
                     onkeydown={handleKeyDown}
-                    placeholder="Type a command..."
+                    placeholder={labels.commandPalettePlaceholder}
                     type="text"
                   />
                   <span
                     class="slds-icon_container slds-icon-utility-down slds-input__icon slds-input__icon_right"
-                    title="Show commands"
+                    title={labels.commandPaletteShowCommandsTitle}
                   >
                     <svg
                       aria-hidden="true"
@@ -93,7 +99,7 @@
                   </span>
                 </div>
                 <div
-                  aria-label="Commands"
+                  aria-label={labels.commandPaletteCommandsAriaLabel}
                   class="slds-dropdown slds-dropdown_length-5 slds-dropdown_fluid"
                   role="listbox"
                   lwc:ref="listbox"

--- a/src/content_scripts/modules/x/commandPallet/commandPallet.js
+++ b/src/content_scripts/modules/x/commandPallet/commandPallet.js
@@ -1,10 +1,23 @@
 import { api, LightningElement, track } from 'lwc';
 import uFuzzy from '@leeoniya/ufuzzy';
 import VirtualScroller from '../../virtualScroller/virtualScroller';
-import { Channel, CHANNEL_OPEN_POPUP } from '../../../../shared';
+import { Channel, CHANNEL_OPEN_POPUP, getLabels } from '../../../../shared';
+
+const labels = getLabels([
+  'commandPaletteHelpTitle',
+  'commandPaletteHelpAssistive',
+  'commandPaletteCloseAssistive',
+  'commandPaletteTitle',
+  'commandPaletteCommandLabel',
+  'commandPalettePlaceholder',
+  'commandPaletteShowCommandsTitle',
+  'commandPaletteCommandsAriaLabel',
+]);
 
 export default class CommandPallet extends LightningElement {
   static renderMode = 'light';
+
+  labels = labels;
 
   /**
    * Fuzzy search engine instance

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,8 +1,9 @@
 {
-  "name": "Force Navigator Reloaded",
+  "name": "__MSG_extensionName__",
   "manifest_version": 3,
   "version": "5.6.4",
-  "description": "Fast, efficient Salesforce Lightning navigation with a command palette—search and act without leaving your keyboard.",
+  "description": "__MSG_extensionDescription__",
+  "default_locale": "en",
   "background": {
     "service_worker": "background.js"
   },
@@ -31,7 +32,7 @@
         "default": "Ctrl+Shift+L",
         "mac": "Command+Shift+P"
       },
-      "description": "Toggle Command Palette"
+      "description": "__MSG_commandTogglePaletteDescription__"
     }
   },
   "content_scripts": [

--- a/src/options/modules/x/jsonCommandUsage/jsonCommandUsage.html
+++ b/src/options/modules/x/jsonCommandUsage/jsonCommandUsage.html
@@ -1,7 +1,7 @@
 <template lwc:render-mode="light">
   <div class="slds-box slds-scope slds-var-sizing_border slds-p-around_medium">
     <h2 class="slds-text-heading_small slds-var-m-bottom_small">
-      Command Usage
+      {labels.optionsCommandUsageHeading}
     </h2>
     <x-json-editor read-only value={usageData}></x-json-editor>
     <template lwc:if={usageError}>

--- a/src/options/modules/x/jsonCommandUsage/jsonCommandUsage.js
+++ b/src/options/modules/x/jsonCommandUsage/jsonCommandUsage.js
@@ -1,8 +1,12 @@
 import { LightningElement, track } from 'lwc';
-import { UsageTracker } from '../../../../shared';
+import { getLabels, UsageTracker } from '../../../../shared';
+
+const labels = getLabels(['optionsCommandUsageHeading', 'errorLoadUsage']);
 
 export default class JsonCommandUsage extends LightningElement {
   static renderMode = 'light';
+
+  labels = labels;
 
   @track usageData = {};
   @track usageError = '';
@@ -18,7 +22,7 @@ export default class JsonCommandUsage extends LightningElement {
       this.usageData = this.cloneValue(usageMap) || {};
       this.usageError = '';
     } catch (err) {
-      const message = err?.message || 'Unable to load usage statistics';
+      const message = err?.message || this.labels.errorLoadUsage;
       this.usageError = message;
       this.usageData = {};
     }

--- a/src/options/modules/x/jsonSettings/jsonSettings.html
+++ b/src/options/modules/x/jsonSettings/jsonSettings.html
@@ -1,6 +1,8 @@
 <template lwc:render-mode="light">
   <div class="slds-box slds-scope slds-var-sizing_border slds-p-around_medium">
-    <h2 class="slds-text-heading_small slds-var-m-bottom_small">Settings</h2>
+    <h2 class="slds-text-heading_small slds-var-m-bottom_small">
+      {labels.optionsSettingsHeading}
+    </h2>
     <x-json-editor lwc:ref="editor" value={data}></x-json-editor>
     <div class="actions slds-var-m-top_small slds-grid slds-grid_align-end">
       <p
@@ -10,13 +12,13 @@
         {error}
       </p>
       <button class="slds-button slds-button_neutral" onclick={handleReset}>
-        Reset to Defaults
+        {labels.optionsResetDefaults}
       </button>
       <button
         class="slds-button slds-button_brand slds-var-m-left_x-small"
         onclick={handleSave}
       >
-        Save
+        {labels.optionsSave}
       </button>
     </div>
   </div>

--- a/src/options/modules/x/jsonSettings/jsonSettings.js
+++ b/src/options/modules/x/jsonSettings/jsonSettings.js
@@ -1,8 +1,25 @@
 import { LightningElement, track } from 'lwc';
-import { loadSettings, resetSettings, saveSettings } from '../../../../shared';
+import {
+  getLabels,
+  loadSettings,
+  resetSettings,
+  saveSettings,
+} from '../../../../shared';
+
+const labels = getLabels([
+  'optionsSettingsHeading',
+  'optionsResetDefaults',
+  'optionsSave',
+  'errorLoadSettings',
+  'errorSaveSettings',
+  'errorResetSettings',
+  'errorInvalidJson',
+]);
 
 export default class JsonSettings extends LightningElement {
   static renderMode = 'light';
+
+  labels = labels;
 
   @track data;
   @track error = '';
@@ -17,7 +34,7 @@ export default class JsonSettings extends LightningElement {
       this.data = this.cloneValue(settings);
       this.error = '';
     } catch (err) {
-      const message = err?.message || 'Unable to load settings';
+      const message = err?.message || this.labels.errorLoadSettings;
       this.error = message;
     }
   }
@@ -36,10 +53,10 @@ export default class JsonSettings extends LightningElement {
       this.error = '';
     } catch (err) {
       if (err instanceof SyntaxError) {
-        this.error = 'Invalid JSON';
+        this.error = this.labels.errorInvalidJson;
         return;
       }
-      const message = err?.message || 'Unable to save settings';
+      const message = err?.message || this.labels.errorSaveSettings;
       this.error = message;
     }
   }
@@ -50,7 +67,7 @@ export default class JsonSettings extends LightningElement {
       this.data = this.cloneValue(settings);
       this.error = '';
     } catch (err) {
-      const message = err?.message || 'Unable to reset settings';
+      const message = err?.message || this.labels.errorResetSettings;
       this.error = message;
     }
   }

--- a/src/options/modules/x/optionsApp/optionsApp.html
+++ b/src/options/modules/x/optionsApp/optionsApp.html
@@ -1,7 +1,7 @@
 <template lwc:render-mode="light">
   <div class="slds-scope slds-p-around_medium">
     <h1 class="slds-text-heading_large slds-var-m-bottom_medium">
-      Force Navigator Reloaded Settings
+      {labels.optionsTitle}
     </h1>
     <div class="slds-grid slds-wrap slds-grid_pull-padded">
       <div class="slds-size_1-of-1 slds-large-size_1-of-2 slds-p-around_small">

--- a/src/options/modules/x/optionsApp/optionsApp.js
+++ b/src/options/modules/x/optionsApp/optionsApp.js
@@ -1,8 +1,13 @@
 import { LightningElement } from 'lwc';
+import { getLabels } from '../../../../shared';
+
+const labels = getLabels(['optionsTitle']);
 
 /**
  * Root component for the options page.
  */
 export default class OptionsApp extends LightningElement {
   static renderMode = 'light';
+
+  labels = labels;
 }

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>Force Navigator Settings</title>
+    <title data-i18n="optionsPageTitle">Force Navigator Settings</title>
     <link
       href="https://unpkg.com/@salesforce-ux/design-system/assets/styles/salesforce-lightning-design-system.min.css"
       rel="stylesheet"

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,11 +1,20 @@
 import { createElement } from 'lwc';
 import OptionsApp from 'x/optionsApp';
+import { applyI18n, getMessage } from '../shared';
 
 /**
  * Mount the options page LWC component once DOM is ready.
  * @returns {void}
  */
 document.addEventListener('DOMContentLoaded', () => {
+  applyI18n(document);
+  const title = getMessage('optionsPageTitle');
+  if (title) {
+    document.title = title;
+  }
+  if (chrome?.i18n?.getUILanguage) {
+    document.documentElement.lang = chrome.i18n.getUILanguage();
+  }
   const elm = createElement('x-options-app', { is: OptionsApp });
   document.body.appendChild(elm);
 });

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -3,41 +3,63 @@
   <head>
     <meta charset="utf-8" />
     <meta content="width=device-width, initial-scale=1" name="viewport" />
-    <title>Force Navigator Reloaded</title>
-    <meta
-      content="Quick reference for Force Navigator Reloaded extension shortcuts and settings."
-      name="description"
-    />
+    <title data-i18n="extensionName">Force Navigator Reloaded</title>
+    <meta data-i18n-attr="content:popupMetaDescription" name="description" />
     <link href="popup.css" rel="stylesheet" />
   </head>
   <body>
     <header>
-      <h1>Force Navigator Reloaded</h1>
+      <h1 data-i18n="extensionName">Force Navigator Reloaded</h1>
     </header>
 
     <main>
       <section aria-labelledby="shortcuts-title">
-        <h2 class="visually-hidden" id="shortcuts-title">Shortcut</h2>
+        <h2
+          class="visually-hidden"
+          data-i18n="popupShortcutHeading"
+          id="shortcuts-title"
+        >
+          Shortcut
+        </h2>
         <p class="shortcut">
-          Open the command palette with
+          <span data-i18n="popupShortcutIntro"
+            >Open the command palette with</span
+          >
           <kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>L</kbd>
-          (Windows) or
-          <kbd>⌘</kbd><kbd>Shift</kbd><kbd>P</kbd> (Mac). <br />
-          You can change this in
-          <a href="#" id="shortcuts-link">Chrome Extension Shortcuts</a>.
-          <br />Press the shortcut again or <kbd>Esc</kbd> to close the palette.
+          <span data-i18n="popupShortcutWindowsSuffix">(Windows) or</span>
+          <kbd>⌘</kbd><kbd>Shift</kbd><kbd>P</kbd>
+          <span data-i18n="popupShortcutMacSuffix">(Mac).</span>
+          <br />
+          <span data-i18n="popupShortcutChangeIntro"
+            >You can change this in</span
+          >
+          <a data-i18n="popupShortcutLink" href="#" id="shortcuts-link">
+            Chrome Extension Shortcuts
+          </a>
+          <br />
+          <span data-i18n="popupShortcutClosePrefix">
+            Press the shortcut again or
+          </span>
+          <kbd>Esc</kbd>
+          <span data-i18n="popupShortcutCloseSuffix"
+            >to close the palette.</span
+          >
         </p>
       </section>
 
       <section>
         <p>
-          For advanced configuration open
-          <a href="#" id="settings-link">Settings</a>.
+          <span data-i18n="popupAdvancedIntro"
+            >For advanced configuration open</span
+          >
+          <a data-i18n="popupSettingsLink" href="#" id="settings-link">
+            Settings </a
+          >.
         </p>
       </section>
 
       <section>
-        <p>
+        <p data-i18n="popupContribute">
           We ❤️ contributions! Feel free to open an issue or send a PR on
           GitHub.
         </p>
@@ -45,12 +67,16 @@
 
       <section>
         <p>
-          If you enjoy using Force Navigator Reloaded,
+          <span data-i18n="popupReviewIntro">
+            If you enjoy using Force Navigator Reloaded,
+          </span>
           <a
             href="https://chromewebstore.google.com/detail/force-navigator-reloaded/iniflnopffblekndhplennjijdcfkeak/reviews?utm_source=github"
             rel="noreferrer"
             target="_blank"
-            >please leave a review</a
+            data-i18n="popupReviewLink"
+          >
+            please leave a review </a
           >.
         </p>
       </section>
@@ -64,8 +90,10 @@
             id="github-link"
             rel="noreferrer"
             target="_blank"
-            >Repository</a
+            data-i18n="popupFooterRepository"
           >
+            Repository
+          </a>
         </li>
         <li>
           <a
@@ -73,13 +101,20 @@
             id="issues-link"
             rel="noreferrer"
             target="_blank"
-            >Report issue</a
+            data-i18n="popupFooterReportIssue"
           >
+            Report issue
+          </a>
         </li>
         <li>
-          <a href="https://github.com/damecek" rel="noreferrer" target="_blank"
-            >Author</a
+          <a
+            data-i18n="popupFooterAuthor"
+            href="https://github.com/damecek"
+            rel="noreferrer"
+            target="_blank"
           >
+            Author
+          </a>
         </li>
       </ul>
     </footer>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -1,8 +1,18 @@
+import { applyI18n, getMessage } from '../shared';
+
 /**
  * Popup script entry point: initializes popup UI on DOMContentLoaded.
  * @returns {void}
  */
 document.addEventListener('DOMContentLoaded', () => {
+  applyI18n(document);
+  const pageTitle = getMessage('extensionName');
+  if (pageTitle) {
+    document.title = pageTitle;
+  }
+  if (chrome?.i18n?.getUILanguage) {
+    document.documentElement.lang = chrome.i18n.getUILanguage();
+  }
   const settings = document.getElementById('settings-link');
   if (settings) {
     settings.addEventListener('click', (event) => {

--- a/src/shared/i18n.js
+++ b/src/shared/i18n.js
@@ -1,0 +1,72 @@
+/**
+ * Get a localized message from the Chrome i18n API.
+ * @param {string} key
+ * @param {string|string[]=} substitutions
+ * @returns {string}
+ */
+export function getMessage(key, substitutions) {
+  const message = chrome?.i18n?.getMessage
+    ? chrome.i18n.getMessage(key, substitutions)
+    : '';
+  return message || key;
+}
+
+/**
+ * Create a map of localized labels from a list of keys.
+ * @param {string[]} keys
+ * @returns {Record<string, string>}
+ */
+export function getLabels(keys) {
+  if (!Array.isArray(keys)) {
+    return {};
+  }
+  return keys.reduce((labels, key) => {
+    if (key) {
+      labels[key] = getMessage(key);
+    }
+    return labels;
+  }, {});
+}
+
+/**
+ * Apply localized messages to elements with data attributes.
+ * @param {Document|HTMLElement} root
+ * @returns {void}
+ */
+export function applyI18n(root) {
+  if (!root?.querySelectorAll) {
+    return;
+  }
+
+  root.querySelectorAll('[data-i18n]').forEach((element) => {
+    const key = element.getAttribute('data-i18n');
+    if (!key) {
+      return;
+    }
+    const message = getMessage(key);
+    if (message) {
+      element.textContent = message;
+    }
+  });
+
+  root.querySelectorAll('[data-i18n-attr]').forEach((element) => {
+    const mapping = element.getAttribute('data-i18n-attr');
+    if (!mapping) {
+      return;
+    }
+    mapping
+      .split(';')
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+      .forEach((entry) => {
+        const [attr, key] = entry.split(':').map((value) => value.trim());
+        if (!attr || !key) {
+          return;
+        }
+        const message = getMessage(key);
+        if (message) {
+          element.setAttribute(attr, message);
+        }
+      });
+  });
+}

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -1,6 +1,7 @@
 export { default as CacheManager } from './cacheManager.js';
 export { default as Channel } from './channel.js';
 export { default as UsageTracker } from './usageTracker.js';
+export * from './i18n.js';
 export * from './constants.js';
 export * from './urlUtils.js';
 export * from './settings.js';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -73,13 +73,14 @@ module.exports = (env, argv) => {
             transform(content) {
               const manifest = JSON.parse(content.toString());
               manifest.key = isProd ? PROD_KEY : DEV_KEY;
-              manifest.name = manifest.name + (isProd ? '' : ' (Dev)');
+              manifest.name = isProd ? manifest.name : `${manifest.name} (Dev)`;
               manifest.oauth2.client_id = isProd
                 ? PROD_CLIENT_ID
                 : DEV_CLIENT_ID;
               return JSON.stringify(manifest, null, 2);
             },
           },
+          { from: 'src/_locales', to: '_locales' },
           { from: 'src/popup/popup.html', to: 'popup.html' },
           { from: 'src/popup/popup.css', to: 'popup.css' },
           { from: 'src/options/options.html', to: 'options.html' },


### PR DESCRIPTION
### Motivation
- Provide Chrome i18n support for many hard-coded command labels and prefixes so the command palette and UI can be localized. 
- Replace inline English strings used for static commands, object manager section names and generated command prefixes with i18n keys and templates. 
- Make it straightforward to format dynamic labels (e.g. including runtime object/flow names) via substitution-aware helper functions. 

### Description
- Add `src/shared/i18n.js` and re-export it from `src/shared/index.js`, providing `getMessage`, `getLabels`, and `applyI18n` helpers for localization. 
- Introduce `src/_locales/en/messages.json` with new entries for static commands, object manager section labels, and template keys used for dynamic command labels. 
- Localize static command labels by switching `src/background/staticCommands.js` to use `getLabels`. 
- Localize dynamic command prefixes in `src/background/commandRegister.js` using `getMessage` with substitutions and use `getLabels` for section labels. 
- Update command classes and UI to consume localized strings: several `src/content_scripts` command classes (`AuthorizeExtensionCommand`, `ExtensionOptionsCommand`, `RefreshCommandListCommand`, `ResetCommandListUsageTracking`) now use `getLabels`; the command palette component uses `getLabels` and template strings. 
- Add `data-i18n` / `data-i18n-attr` markers and call `applyI18n(document)` in `src/popup/popup.js` and `src/options/options.js`, and wire page titles via `getMessage`. 
- Update `src/manifest.json` to use `__MSG_*__` placeholders and set `default_locale`, and update `webpack.config.js` to copy the `_locales` folder into the build. 
- Document guidance in `AGENTS.md` to prefer `getMessage` when substitutions are required. 

### Testing
- Ran `npm run lint` (which runs `eslint`) and the lint task completed successfully, with an `npm` warning about an unknown env config `http-proxy`. 
- Prettier/formatting hooks ran as part of the commit pipeline and completed successfully during the commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a5144e9fc83288af3bfffa7352f49)