### PR TITLE
Rename commandPallet → commandPalette across LWC component

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ action.
 - **Content Script** (`src/content_scripts`): Injects the LWC app into Salesforce pages and handles communication with
   the background script
 - **LWC Components** (`src/content_scripts/modules/x`): Lightning Web Components that provide the UI for the command
-  palette
+  palette (including the `commandPalette` component)
 - **Popup** (`src/popup`): Provides quick usage tips and links to settings and GitHub, with automatic light/dark theme
   styling
 - **Options Page** (`src/options` and `src/options/modules`): Settings UI built with LWC

--- a/src/content_scripts/modules/x/app/app.html
+++ b/src/content_scripts/modules/x/app/app.html
@@ -1,8 +1,8 @@
 <template lwc:render-mode="light">
-  <x-command-pallet
+  <x-command-palette
     commands={commands}
     lwc:if={isCommandPaletteVisible}
     onclose={handleClose}
     lwc:ref="palette"
-  ></x-command-pallet>
+  ></x-command-palette>
 </template>

--- a/src/content_scripts/modules/x/commandPalette/commandPalette.css
+++ b/src/content_scripts/modules/x/commandPalette/commandPalette.css
@@ -8,24 +8,24 @@
     z-index: 10000;
 }
 
-x-command-pallet .slds-modal__content {
+x-command-palette .slds-modal__content {
     overflow: visible;
 }
 
-x-command-pallet .slds-modal {
+x-command-palette .slds-modal {
     z-index: 9060;
 }
 
-x-command-pallet .slds-scope .slds-modal__content {
+x-command-palette .slds-scope .slds-modal__content {
     overflow: visible;
 }
 
-x-command-pallet .modal-container.slds-modal__container {
+x-command-palette .modal-container.slds-modal__container {
     max-width: 50rem;
     padding-bottom: 20rem;
 }
 
-x-command-pallet .command-pallet__help-icon {
+x-command-palette .command-palette__help-icon {
     align-items: center;
     display: inline-flex;
     font-size: 1.1rem;

--- a/src/content_scripts/modules/x/commandPalette/commandPalette.html
+++ b/src/content_scripts/modules/x/commandPalette/commandPalette.html
@@ -13,7 +13,7 @@
           onclick={handleHelp}
           title="Help"
         >
-          <span aria-hidden="true" class="command-pallet__help-icon">?</span>
+          <span aria-hidden="true" class="command-palette__help-icon">?</span>
           <span class="slds-assistive-text">Help</span>
         </button>
         <button

--- a/src/content_scripts/modules/x/commandPalette/commandPalette.js
+++ b/src/content_scripts/modules/x/commandPalette/commandPalette.js
@@ -3,7 +3,7 @@ import uFuzzy from '@leeoniya/ufuzzy';
 import VirtualScroller from '../../virtualScroller/virtualScroller';
 import { Channel, CHANNEL_OPEN_POPUP } from '../../../../shared';
 
-export default class CommandPallet extends LightningElement {
+export default class CommandPalette extends LightningElement {
   static renderMode = 'light';
 
   /**
@@ -34,7 +34,7 @@ export default class CommandPallet extends LightningElement {
   set commands(value) {
     this._commands = Array.isArray(value) ? value : [];
     this.filteredCommands = [...this._commands].sort(this.usageSort);
-    console.log('CommandPallet commands set:', this.filteredCommands);
+    console.log('CommandPalette commands set:', this.filteredCommands);
     this.selectedIndex = 0;
     this._visibleStart = 0;
     this._visibleEnd = 20;


### PR DESCRIPTION
### Motivation
- Fix the typo `pallet` → `palette` in the command-palette component and related assets to improve clarity and consistency across the codebase.
- Ensure the component name, CSS selectors, and documentation all match the intended `commandPalette` naming.

### Description
- Rename directory `src/content_scripts/modules/x/commandPallet` to `src/content_scripts/modules/x/commandPalette` and move the component files accordingly.
- Change the component class from `CommandPallet` to `CommandPalette` and update the console message to `CommandPalette commands set:`.
- Update the usage of the LWC tag from `<x-command-pallet>` to `<x-command-palette>` in `src/content_scripts/modules/x/app/app.html`.
- Update CSS selectors and help-icon class names from `command-pallet`/`command-pallet__help-icon` to `command-palette`/`command-palette__help-icon` and update `README.md` to mention the `commandPalette` component.

### Testing
- Ran pre-commit formatting (`prettier --write` via `lint-staged`/Husky) as part of the commit workflow and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981e479cfd483289db5d0bdf9e46eb2)